### PR TITLE
Make buttons disable, for User and Admin

### DIFF
--- a/src/components/userPage/useredit/UserEditRoles.js
+++ b/src/components/userPage/useredit/UserEditRoles.js
@@ -2,27 +2,29 @@ import React from 'react';
 import UserOutlined from "@ant-design/icons/lib/icons/UserOutlined";
 import {Form, Radio} from "antd";
 
-const UserEditRoles =({user}) => {
-function disable(value){
-    if (value===user.roleName){
-        return false;
+const UserEditRoles = ({user}) => {
+    function disable(value) {
+        if (value === "ROLE_USER" || value ==="ROLE_ADMIN") {
+            return true;
+        } else if (value === "ROLE_MANAGER")
+            return false;
     }
-    else return true;
-}
+
     return (
-        <Form.Item name="roleName"  initialValue={user.roleName}>
+        <Form.Item name="roleName" initialValue={user.roleName}>
             <Radio.Group className="button-container"
                          optionType="button"
                          buttonStyle="solid"
             >
-
-                <Radio.Button value="ROLE_USER">
+                <Radio.Button value="ROLE_USER"
+                              disabled={disable(user.roleName)}>
                     <div className="button-box">
                         <div className="ellipse"><UserOutlined className="user-icon"/></div>
                         <div className="role-name"> Відвідувач</div>
                     </div>
                 </Radio.Button>
-                <Radio.Button value="ROLE_MANAGER">
+                <Radio.Button value="ROLE_MANAGER"
+                              disabled={disable(user.roleName)}>
                     <div className="button-box">
                         <div className="ellipse"><UserOutlined className="user-icon"/></div>
                         <div className="role-name"> Керівник</div>


### PR DESCRIPTION
dev

## Summary of issue

Admin and user can change the role, it is necessary to make that the admin cannot change a role for himself, and the user cannot change his role to manager

## Summary of change

Make buttons disable, for user and admin

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
