### PR TITLE
add empty values for work with clubs without canter or/and locations

### DIFF
--- a/src/components/editClub/tabs/ContactsTab.js
+++ b/src/components/editClub/tabs/ContactsTab.js
@@ -116,7 +116,7 @@ const ContactsTab = ({contacts, cities, setResult, result}) => {
                 <Form.Item name="cityName"
                            className="edit-club-row"
                            label="Місто"
-                           initialValue={result.locations[FIRST_LOCATION].cityName}
+                           initialValue={result.locations.length ? result.locations[FIRST_LOCATION].cityName : ""}
                 >
                     <Select
                         className="edit-club-select"
@@ -139,7 +139,7 @@ const ContactsTab = ({contacts, cities, setResult, result}) => {
                 <Form.Item name="districtName"
                            className="edit-club-row"
                            label="Район"
-                           initialValue={result.locations[FIRST_LOCATION].districtName}
+                           initialValue={result.locations.length ? result.locations[FIRST_LOCATION].districtName : ""}
                            >
                     <Select
                         className="edit-club-select"
@@ -151,7 +151,7 @@ const ContactsTab = ({contacts, cities, setResult, result}) => {
                 <Form.Item name="stationName"
                            className="edit-club-row"
                            label="Станція/зупинка"
-                           initialValue={result.locations[FIRST_LOCATION].stationName}
+                           initialValue={result.locations.length ? result.locations[FIRST_LOCATION].stationName : ""}
                 >
                     <Select
                         className="edit-club-select"
@@ -164,14 +164,14 @@ const ContactsTab = ({contacts, cities, setResult, result}) => {
             <Form.Item name="address"
                        className="edit-club-row"
                        label="Адреса"
-                       initialValue={result.locations[FIRST_LOCATION].address}
+                       initialValue={result.locations.length ? result.locations[FIRST_LOCATION].address : ""}
                        // validateTrigger={handleSelect}
                        // {...inputAddressProps}
             >
                 <Input className="edit-club-input"
-                       value={result.locations[FIRST_LOCATION].address}
+                       value={result.locations.length ? result.locations[FIRST_LOCATION].address : ""}
                        placeholder="Адреса"
-                       defaultValue={result.locations[FIRST_LOCATION].address}
+                       defaultValue={result.locations.length ? result.locations[FIRST_LOCATION].address : ""}
                 />
                 {/*<EditClubInputAddress*/}
                 {/*    placeholder={result.address}*/}

--- a/src/components/editClub/tabs/MainInformationTab.js
+++ b/src/components/editClub/tabs/MainInformationTab.js
@@ -79,7 +79,7 @@ const MainInformationTab = ({categories, centers, setResult, result}) => {
             <Form.Item name="centerName"
                        className="edit-club-row"
                        label="Приналежність до центру"
-                       initialValue={result.center.name}>
+                       initialValue={result.center ? result.center.name : ""}>
                 <Select
                     className="edit-club-select"
                     placeholder="Обрати центр"


### PR DESCRIPTION

dev
## JIRA

* [Main JIRA ticket](https://jira.softserve.academy/secure/RapidBoard.jspa?rapidView=id)


## Code reviewers

- [ ] @github_username

### Second Level Review

- [ ] @github_username

## Summary of issue

Problem with displaying updating form for clubs without canter or/and locations.

## Summary of change

Add empty values for work with clubs without canter or/and locations.

## Testing approach

Create club without center, locations (online), both. And then try to change something by "Редагувати гурток".

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
